### PR TITLE
Refactor application routes to adjust height filtering logic for prod…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,43 @@
 # DDGRO Backend - Lista Zmian
 
+## Wersja 2.1.5 — 2026-03-29
+
+### Oferta PDF / podstawienia serii (STANDARD + SPIRAL przy niskiej wysokości)
+
+**Problem:** Przy `main_system: standard` i zakresie wysokości obejmującym mm poniżej 30 (np. lowest 25 mm) macierz `m_spiral` ma niezerowy bucket **`17-30`**, ale klucz ten ma `to = 30` w `parseRangeKey`, więc warunek **`to < 30`** go wykluczał. W efekcie `spiralKeys` było puste, w PDF tylko STANDARD, a suma sztuk z linii nie zgadzała się z `supports_count`.
+
+**Zmiany:**
+
+| Obszar | Plik | Opis |
+|--------|------|------|
+| Klucze SPIRAL/MAX przy podstawieniach | `utils/substitution-rules.js` | Dla **standard**: `r.to <= 30` (włącza **`17-30`**). Dla **max**: `r.to <= 45` (spójna granica). |
+| Kolejność produktów w ofercie | `routes/api/application.js` | `standardLower`: `height.to <= 30`; `maxLower`: `height.to <= 45` (dwa miejsca: główny flow + send-order). |
+| Testy | `utils/__tests__/substitution-rules.test.js` | Zaktualizowane oczekiwania (m.in. **`17-30`** w `spiralKeys` przy STANDARD). |
+
+**Wpływ:** Przy hybrydzie STANDARD pojawia się linia **SPIRAL** dla niskich zakresów; suma z macierzy znowu przechodzi przez pipeline produktów.
+
+---
+
+### Zgodność ilości w PDF z `supports_count` (podpory vs podkładki)
+
+**Problem:** Ilości z macierzy są ułamkowe; **`Math.round` na każdej linii** dawało sumę większą niż `supports_count` (np. 35+130+156 = **321** przy **320**), co rozjeżdżało się z podkładkami ustawionymi na `supports_count`.
+
+**Zmiany:**
+
+| Obszar | Plik | Opis |
+|--------|------|------|
+| Rekonsyliacja całkowitych sztuk | `utils/reconcile-pedestal-counts.js` | Nowa funkcja: metoda **największych reszt** — suma linii podpór = `application.supports_count`. |
+| Generowanie zamówienia / PDF | `routes/api/application.js` | `addCountAndPriceToItems` zostawia **surowe** wartości z macierzy; po złożeniu spiral+standard+max+raptor wywołanie **`reconcilePedestalLineCounts`** (przed `application.products` i akcesoriami). |
+| Testy | `utils/__tests__/reconcile-pedestal-counts.test.js` | Scenariusz z realnym rozjazdem 321 → 320. |
+
+**Wpływ:** W PDF suma sztuk **podpór regulowanych** zgadza się z **`supports_count`** i z ilością podkładek, gdy ta wynika z `supports_count`.
+
+---
+
+**Wersja aplikacji:** `VER` w `.env` / zmiennych środowiska oraz `version` w `server/package.json` — **2.1.5** (endpoint główny zwraca `version` z `process.env.VER`).
+
+---
+
 ## Data: 2025-09-09
 
 ### ❗ KRYTYCZNE ZMIANY W OBLICZENIACH I GENEROWANIU PDF

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddgro-nowy-backend",
-  "version": "0.0.0",
+  "version": "2.1.5",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/routes/api/application.js
+++ b/routes/api/application.js
@@ -15,6 +15,9 @@ const { createZBIORCZA_TP } = require('../../utils/create-zbiorcza-tp');
 const {
   getKeysPerSeries,
 } = require('../../utils/substitution-rules');
+const {
+  reconcilePedestalLineCounts,
+} = require('../../utils/reconcile-pedestal-counts');
 const Products = require('../../models/Products');
 
 const sendEmail = require('../../services/sendEmail');
@@ -210,7 +213,7 @@ router.get('/preview/:id', async function (req, res, next) {
         // Standard covers 30-420mm
         const standardLower = filteredSpiral.filter((p) => {
           const range = getHeightRange(p.height_mm);
-          return range && range.to < 30;
+          return range && range.to <= 30;
         });
         const standardMain = filteredStandard;
         const standardUpper = filteredMax.filter((p) => {
@@ -236,7 +239,7 @@ router.get('/preview/:id', async function (req, res, next) {
         // Max covers 45-950mm
         const maxLower = filteredSpiral.filter((p) => {
           const range = getHeightRange(p.height_mm);
-          return range && range.to < 45;
+          return range && range.to <= 45;
         });
         const maxMain = filteredMax;
         orderArr = [...maxLower, ...maxMain];
@@ -583,7 +586,7 @@ router.post('/send-order-summary/:id', async function (req, res, next) {
       case 'standard':
         const standardLower = filteredSpiral.filter((p) => {
           const range = getHeightRange(p.height_mm);
-          return range && range.to < 30;
+          return range && range.to <= 30;
         });
         const standardMain = filteredStandard;
         const standardUpper = filteredMax.filter((p) => {
@@ -605,7 +608,7 @@ router.post('/send-order-summary/:id', async function (req, res, next) {
       case 'max':
         const maxLower = filteredSpiral.filter((p) => {
           const range = getHeightRange(p.height_mm);
-          return range && range.to < 45;
+          return range && range.to <= 45;
         });
         const maxMain = filteredMax;
         orderArr = [...maxLower, ...maxMain];
@@ -714,18 +717,18 @@ router.post('/send-order-summary/:id', async function (req, res, next) {
       return items
         .filter((item) => {
           const normalizedHeight = normalizeHeight(item.height_mm);
-          const itemCount = Math.round(countObj[normalizedHeight] || 0);
+          const raw = Number(countObj[normalizedHeight]) || 0;
           return (
-            itemCount > 0 && item.series?.toLowerCase() === series.toLowerCase()
+            raw > 0 && item.series?.toLowerCase() === series.toLowerCase()
           );
         })
         .map((item) => {
           const normalizedHeight = normalizeHeight(item.height_mm);
-          const count = Math.round(countObj[normalizedHeight] || 0);
+          const count = Number(countObj[normalizedHeight]) || 0;
           const priceNet = getPriceNet(item);
           return {
             ...item,
-            count: count,
+            count,
             total_price: (count * priceNet).toFixed(2),
           };
         });
@@ -755,6 +758,12 @@ router.post('/send-order-summary/:id', async function (req, res, next) {
     );
 
     items = [...spiralItems, ...standardItems, ...maxItems, ...raptorItems];
+
+    items = reconcilePedestalLineCounts(
+      items,
+      application.supports_count,
+      getPriceNet,
+    );
 
     // Add products from application.products with full info
     const additionalProducts = application.products || [];

--- a/utils/__tests__/reconcile-pedestal-counts.test.js
+++ b/utils/__tests__/reconcile-pedestal-counts.test.js
@@ -1,0 +1,31 @@
+const {
+  reconcilePedestalLineCounts,
+} = require('../reconcile-pedestal-counts');
+
+const price2 = () => 2;
+
+describe('reconcilePedestalLineCounts', () => {
+  it('sumuje do supports_count (case 25–63 mm: 34.59+129.73+155.68 → 320)', () => {
+    const items = [
+      { id: 1, count: 34.5945945945946 },
+      { id: 2, count: 129.7297297297297 },
+      { id: 3, count: 155.67567567567565 },
+    ];
+    const out = reconcilePedestalLineCounts(items, 320, price2);
+    const sum = out.reduce((s, x) => s + x.count, 0);
+    expect(sum).toBe(320);
+    expect(out.map((x) => x.count)).toEqual([34, 130, 156]);
+  });
+
+  it('Math.round na liniach dałby 321 — tu nadal 320', () => {
+    const raw = [34.5945945945946, 129.7297297297297, 155.67567567567565];
+    const naive = raw.map((r) => Math.round(r)).reduce((a, b) => a + b, 0);
+    expect(naive).toBe(321);
+    const out = reconcilePedestalLineCounts(
+      raw.map((count, i) => ({ count, id: i })),
+      320,
+      price2,
+    );
+    expect(out.reduce((s, x) => s + x.count, 0)).toBe(320);
+  });
+});

--- a/utils/__tests__/substitution-rules.test.js
+++ b/utils/__tests__/substitution-rules.test.js
@@ -64,7 +64,7 @@ describe('getKeysPerSeries – RAPTOR (brak podstawień)', () => {
 });
 
 describe('getKeysPerSeries – STANDARD (niższe→SPIRAL, wyższe→MAX)', () => {
-  it('dla zakresu 150–500 mm zwraca SPIRAL (to<30), STANDARD 30–420, MAX >420', () => {
+  it('dla zakresu 150–500 mm zwraca SPIRAL (to<=30), STANDARD 30–420, MAX >420', () => {
     const application = { main_system: 'standard' };
     const zbiorcza_TP = {
       m_spiral: { '10-17': 5, '17-30': 3 },
@@ -73,7 +73,7 @@ describe('getKeysPerSeries – STANDARD (niższe→SPIRAL, wyższe→MAX)', () =
       m_raptor: {},
     };
     const result = getKeysPerSeries(application, zbiorcza_TP);
-    expect(result.spiralKeys).toEqual(['10-17']);
+    expect(result.spiralKeys).toEqual(['10-17', '17-30']);
     expect(result.standardKeys).toEqual(['120-220', '220-320', '320-420']);
     expect(result.maxKeys).toEqual(['350-550']);
     expect(result.raptorKeys).toEqual([]);
@@ -122,7 +122,7 @@ describe('getKeysPerSeries – SPIRAL (wyższe→MAX)', () => {
 });
 
 describe('getKeysPerSeries – MAX (niższe→SPIRAL)', () => {
-  it('dla zakresu 30–100 mm zwraca SPIRAL (to<45) + MAX', () => {
+  it('dla zakresu 30–100 mm zwraca SPIRAL (to<=45) + MAX', () => {
     const application = { main_system: 'max' };
     const zbiorcza_TP = {
       m_spiral: { '17-30': 5, '30-50': 10 },
@@ -206,7 +206,7 @@ describe('getKeysPerSeries – scenariusze podstawiania (ok. 20 przypadków)', (
     expect(result.maxKeys).toEqual(['350-550', '550-750', '750-950']);
   });
 
-  it('4. STANDARD: SPIRAL "17-30" (to=30) NIE wchodzi do spiralKeys (wymóg to<30)', () => {
+  it('4. STANDARD: SPIRAL "17-30" (to=30) wchodzi do spiralKeys (wymóg to<=30)', () => {
     const application = { main_system: 'standard' };
     const zbiorcza_TP = {
       m_spiral: { '17-30': 5 },
@@ -215,10 +215,10 @@ describe('getKeysPerSeries – scenariusze podstawiania (ok. 20 przypadków)', (
       m_raptor: {},
     };
     const result = getKeysPerSeries(application, zbiorcza_TP);
-    expect(result.spiralKeys).toEqual([]);
+    expect(result.spiralKeys).toEqual(['17-30']);
   });
 
-  it('5. STANDARD: oba podstawienia – SPIRAL (to<30) + MAX (to>420)', () => {
+  it('5. STANDARD: oba podstawienia – SPIRAL (to<=30) + MAX (to>420)', () => {
     const application = { main_system: 'standard' };
     const zbiorcza_TP = {
       m_spiral: { '10-17': 8 },
@@ -282,7 +282,7 @@ describe('getKeysPerSeries – scenariusze podstawiania (ok. 20 przypadków)', (
     expect(result.maxKeys).toEqual(['150-350', '350-550', '750-950']);
   });
 
-  it('10. MAX: tylko w zakresie 45–950 mm – brak podstawienia SPIRAL', () => {
+  it('10. MAX: tylko w zakresie powyżej 45 mm – brak podstawienia SPIRAL (spiral od do<=45)', () => {
     const application = { main_system: 'max' };
     const zbiorcza_TP = {
       m_spiral: { '90-110': 20 },
@@ -295,7 +295,7 @@ describe('getKeysPerSeries – scenariusze podstawiania (ok. 20 przypadków)', (
     expect(result.maxKeys).toEqual(['75-150', '350-550']);
   });
 
-  it('11. MAX: granica 45 – SPIRAL "30-50" (to=50) NIE wchodzi do spiralKeys (wymóg to<45)', () => {
+  it('11. MAX: SPIRAL "30-50" (to=50) NIE wchodzi do spiralKeys (wymóg to<=45)', () => {
     const application = { main_system: 'max' };
     const zbiorcza_TP = {
       m_spiral: { '30-50': 25 },
@@ -307,7 +307,7 @@ describe('getKeysPerSeries – scenariusze podstawiania (ok. 20 przypadków)', (
     expect(result.spiralKeys).toEqual([]);
   });
 
-  it('12. MAX: tylko SPIRAL to<45 (10-17, 17-30)', () => {
+  it('12. MAX: tylko SPIRAL to<=45 (10-17, 17-30)', () => {
     const application = { main_system: 'max' };
     const zbiorcza_TP = {
       m_spiral: { '10-17': 5, '17-30': 10 },

--- a/utils/reconcile-pedestal-counts.js
+++ b/utils/reconcile-pedestal-counts.js
@@ -1,0 +1,67 @@
+/**
+ * Zamienia ułamkowe ilości z macierzy na liczby całkowite tak, by suma linii
+ * zgadzała się z application.supports_count (metoda największych reszt).
+ * Zapobiega sytuacji: round(34.59)+round(129.73)+round(155.68) = 321 przy sumie rzeczywistej 320.
+ */
+
+function reconcilePedestalLineCounts(items, targetTotal, getPriceNet) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return items || [];
+  }
+
+  const target = Math.round(Number(targetTotal));
+  if (!Number.isFinite(target) || target < 0) {
+    return items.map((item) => {
+      const count = Math.round(Number(item.count) || 0);
+      const priceNet = getPriceNet(item);
+      return {
+        ...item,
+        count,
+        total_price: (count * priceNet).toFixed(2),
+      };
+    });
+  }
+
+  const raw = items.map((item) => Math.max(0, Number(item.count) || 0));
+  const floors = raw.map((r) => Math.floor(r));
+  const sumFloors = floors.reduce((a, b) => a + b, 0);
+  let deficit = target - sumFloors;
+
+  const byFracDesc = raw
+    .map((r, idx) => ({ idx, frac: r - floors[idx] }))
+    .sort((a, b) => b.frac - a.frac);
+
+  const delta = new Array(items.length).fill(0);
+
+  if (deficit > 0) {
+    let i = 0;
+    for (; i < deficit && i < byFracDesc.length; i++) {
+      delta[byFracDesc[i].idx] += 1;
+    }
+    for (let j = 0; j < deficit - i; j++) {
+      delta[byFracDesc[j % byFracDesc.length].idx] += 1;
+    }
+  } else if (deficit < 0) {
+    const byFracAsc = [...byFracDesc].reverse();
+    let need = -deficit;
+    for (let i = 0; i < byFracAsc.length && need > 0; i++) {
+      const idx = byFracAsc[i].idx;
+      if (floors[idx] + delta[idx] > 0) {
+        delta[idx] -= 1;
+        need -= 1;
+      }
+    }
+  }
+
+  return items.map((item, idx) => {
+    const count = Math.max(0, floors[idx] + delta[idx]);
+    const priceNet = getPriceNet(item);
+    return {
+      ...item,
+      count,
+      total_price: (count * priceNet).toFixed(2),
+    };
+  });
+}
+
+module.exports = { reconcilePedestalLineCounts };

--- a/utils/substitution-rules.js
+++ b/utils/substitution-rules.js
@@ -53,9 +53,11 @@ function getKeysPerSeries(application, zbiorcza_TP) {
       };
     case 'standard':
       return {
+        // SPIRAL dla niskich wysokości: klucz "17-30" ma to=30 — musi być <= 30,
+        // inaczej cały bucket znika z oferty (tylko STANDARD 30–45, 45–70).
         spiralKeys: spiralKeys.filter((k) => {
           const r = parseRangeKey(k);
-          return r && r.to < 30;
+          return r && r.to <= 30;
         }),
         standardKeys,
         maxKeys: maxKeys.filter((k) => {
@@ -78,7 +80,7 @@ function getKeysPerSeries(application, zbiorcza_TP) {
       return {
         spiralKeys: spiralKeys.filter((k) => {
           const r = parseRangeKey(k);
-          return r && r.to < 45;
+          return r && r.to <= 45;
         }),
         standardKeys: [],
         maxKeys,


### PR DESCRIPTION
…uct series, ensuring inclusive range checks (<=) for standard and max categories; integrate reconciliation of pedestal line counts for improved order summary accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected height range boundaries for product selection—SPIRAL/MAX buckets now include the 17–30 height range.
  * Fixed pedestal/support line counts in generated PDFs to match configured support counts.

* **Chores**
  * Updated project version to 2.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->